### PR TITLE
Correct angle_max to avoid fencepost error

### DIFF
--- a/pepperl_fuchs_r2000/src/rosnode/r2000_node.cpp
+++ b/pepperl_fuchs_r2000/src/rosnode/r2000_node.cpp
@@ -122,9 +122,9 @@ void R2000Node::getScanData(const ros::TimerEvent &e)
     scanmsg.header.frame_id = frame_id_;
     scanmsg.header.stamp = ros::Time::now();
 
-    scanmsg.angle_min = -M_PI;
-    scanmsg.angle_max = +M_PI;
     scanmsg.angle_increment = 2*M_PI/float(scandata.distance_data.size());
+    scanmsg.angle_min = -M_PI;
+    scanmsg.angle_max = +M_PI-scanmsg.angle_increment;
     scanmsg.time_increment = 1/35.0f/float(scandata.distance_data.size());
 
     scanmsg.scan_time = 1/std::atof(driver_->getParametersCached().at("scan_frequency").c_str());


### PR DESCRIPTION
The current `r2000_node.cpp` creates scans within the range of `(-π,+π)` with a dynamic `angle_increment` that is defined by the `samples_per_scan` variable. Using this range leads to a fencepost error, where the scan in 0° direction is contained two times and therefore seems to be missing.

Some ROS libraries (e.g. [navigation_2d](https://github.com/skasperski/navigation_2d)) complain about that error and others ignore it. Ignoring it leads to a incorrect conversion of the scan points into 2D coordinates (which is important for accurate SLAM).

Since the deviation is neglible and not necessarily visible (and thus mostly ignored), it can be further rectified by adapting the maximum range of the angle:

```math
angle_min = -π
angle_max = +π-angle_increment
```

Thank you for considering merging this change. :)
