### PR TITLE
"/" in frame_id value

### DIFF
--- a/pepperl_fuchs_r2000/launch/gui_example.launch
+++ b/pepperl_fuchs_r2000/launch/gui_example.launch
@@ -2,7 +2,7 @@
 <launch>
   <node pkg="pepperl_fuchs_r2000" type="r2000_node" name="r2000_driver_node" output="screen">
     <param name="scanner_ip" value="10.0.10.9"/>
-    <param name="frame_id" value="/scan"/>
+    <param name="frame_id" value="scan"/>
     <param name="scan_frequency" value="35"/>
     <param name="samples_per_scan" value="3600"/>
   </node>

--- a/pepperl_fuchs_r2000/launch/r2000.launch
+++ b/pepperl_fuchs_r2000/launch/r2000.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="frame_id" default="/scan"/>
+  <arg name="frame_id" default="scan"/>
   <arg name="scanner_ip" default="10.0.10.9"/>
   <arg name="scan_frequency" default="35"/>
   <arg name="samples_per_scan" default="3600"/>


### PR DESCRIPTION
We had issues with the "/" in the frame_id value of the launch files on ROS Noetic / Ubuntu 20.04.
After removal of the forwardslash in both launch files, they worked well. 